### PR TITLE
bugfix: removed '&' from metadata.xml (invalid XML)

### DIFF
--- a/games-strategy/spring/metadata.xml
+++ b/games-strategy/spring/metadata.xml
@@ -6,7 +6,7 @@
  <flag name='ai'>Compile multiple Artificial Intelligences for SinglePlayer</flag>
  <flag name='java'>Compile Java-based AIs</flag>
  <flag name='default'>Default engine (that's what you want)</flag>
- <flag name='multithreaded'>An engine build with separate threads for Sim & Rendering</flag>
+ <flag name='multithreaded'>An engine build with separate threads for Sim and Rendering</flag>
  <flag name='headless'>A engine build, that doesn't render anything to screen but still runs the full simulations (e.g. used to test AIs, benchmarks, ...)</flag>
  <flag name='dedicated'>A dedicated server build (runs no simulation, just broadcasts netcommands)</flag>
  <flag name='test-ai'>A Null-AI (justs for testing/learning)</flag>


### PR DESCRIPTION
this broke metadata.xml parsing by tools like equery

changed '&' to 'and' because '&amp' isn't very readable
